### PR TITLE
Be able to exclude path url encoding

### DIFF
--- a/engine/src/main/groovy/de/gesellix/docker/engine/OkDockerClient.groovy
+++ b/engine/src/main/groovy/de/gesellix/docker/engine/OkDockerClient.groovy
@@ -163,8 +163,9 @@ class OkDockerClient implements EngineClient {
         }
         String queryAsString = (config.query) ? "${queryToString(config.query as Map)}" : ""
 
+        Boolean pathAlreadyEncoded = config.pathAlreadyEncoded as Boolean
         def urlBuilder = new HttpUrl.Builder()
-                .addPathSegments(path)
+                .addPathSegments(path, pathAlreadyEncoded ?: false)
                 .encodedQuery(queryAsString ?: null)
         def httpUrl = createUrl(urlBuilder, protocol, host, port)
 

--- a/engine/src/test/groovy/de/gesellix/docker/engine/OkDockerClientSpec.groovy
+++ b/engine/src/test/groovy/de/gesellix/docker/engine/OkDockerClientSpec.groovy
@@ -11,6 +11,7 @@ import okhttp3.Interceptor
 import okhttp3.MediaType
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
+import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody
 import okhttp3.WebSocketListener
@@ -953,6 +954,34 @@ class OkDockerClientSpec extends Specification {
         and:
         response.content == null
     }
+
+    def "prepareRequest should urlencode path"() {
+        given:
+        def client = new OkDockerClient()
+        when:
+        def config = [method : "GET",
+                      path   :"path1%2fpath2"]
+        def request = client.prepareRequest(new Request.Builder(),config).build()
+        then:
+        String url = request.url().toString()
+        String urlEnd = "path1%252fpath2"
+        url.substring(url.length() - urlEnd.length()) == urlEnd
+    }
+
+    def "prepareRequest should not urlencode path when add pathAlreadyEncoded:true is added"() {
+        given:
+        def client = new OkDockerClient()
+        when:
+        def config = [method : "GET",
+                      path   :"pathPath1%2fpathPath2",
+                      pathAlreadyEncoded:true]
+        def request = client.prepareRequest(new Request.Builder(),config).build()
+        then:
+        String url = request.url().toString()
+        String urlEnd = "pathPath1%2fpathPath2"
+        url.substring(url.length() - urlEnd.length()) == urlEnd
+    }
+
 
     static class TestContentHandlerFactory implements ContentHandlerFactory {
 


### PR DESCRIPTION
## Motivation

### Problem pushing using _docker-client_
I want to do a something similar to
```
docker push docker.podal.se/podal/build
```
When doing
```
manageContainer.push("docker.podal.se/podal/build:mytag")

manageContainer.push("docker.podal.se%2fpodal%2fbuild:mytag")
```
It result in a POST http://<url>/images/docker.podal.se/podal/build/push?tag=mytag 
and a POST http://<url>/images/docker.podal.se%252fpodal%252fbuild/push?tag=mytag

So _docker-client_ must be able to send an already encoded URL to _docker-engine_

Update will com to _docker-client_
## Functions
When adding **pathAlreadyEncoded:true** in config the url isn't URL-encoded.

 