### PR TITLE
Require okio >= 3.x

### DIFF
--- a/engine/build.gradle.kts
+++ b/engine/build.gradle.kts
@@ -55,7 +55,7 @@ dependencies {
     ).onEach {
       implementation(it) {
         version {
-          strictly("[1.6,1.7)")
+          strictly("[1.4,1.7)")
           prefer("1.6.21")
         }
       }

--- a/engine/build.gradle.kts
+++ b/engine/build.gradle.kts
@@ -39,10 +39,15 @@ dependencies {
         }
       }
     }
-    implementation("com.squareup.okio:okio") {
-      version {
-        strictly("[2.5,4)")
-        prefer("3.1.0")
+    listOf(
+      "com.squareup.okio:okio",
+      "com.squareup.okio:okio-jvm"
+    ).forEach {
+      implementation(it) {
+        version {
+          strictly("[3,4)")
+          prefer("3.1.0")
+        }
       }
     }
     listOf(
@@ -67,7 +72,7 @@ dependencies {
   implementation("org.slf4j:slf4j-api:1.7.36")
   testImplementation("ch.qos.logback:logback-classic:[1.2,2)!!1.2.11")
 
-  implementation("com.squareup.okio:okio:3.1.0")
+  implementation("com.squareup.okio:okio-jvm:3.1.0")
   implementation("com.squareup.okhttp3:okhttp:4.9.3")
   testImplementation("com.squareup.okhttp3:mockwebserver:4.9.3")
 

--- a/integrationtest/build.gradle.kts
+++ b/integrationtest/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
     }
     implementation("com.squareup.okio:okio") {
       version {
-        strictly("[2.5,4)")
+        strictly("[3,4)")
         prefer("3.1.0")
       }
     }

--- a/integrationtest/build.gradle.kts
+++ b/integrationtest/build.gradle.kts
@@ -41,14 +41,13 @@ dependencies {
     listOf(
       "org.jetbrains.kotlin:kotlin-reflect",
       "org.jetbrains.kotlin:kotlin-stdlib",
-      "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
       "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
       "org.jetbrains.kotlin:kotlin-stdlib-common",
       "org.jetbrains.kotlin:kotlin-test"
     ).onEach {
       implementation(it) {
         version {
-          strictly("[1.6,1.7)")
+          strictly("[1.4,1.7)")
           prefer("1.6.21")
         }
       }


### PR DESCRIPTION
Explicitly using okio-jvm makes the artifacts Maven-compatible.

Relates to https://github.com/gesellix/docker-client/issues/245
