### PR TITLE
Fail with an explicit exception for invalid versions

### DIFF
--- a/engine/src/main/java/de/gesellix/docker/engine/DockerVersion.java
+++ b/engine/src/main/java/de/gesellix/docker/engine/DockerVersion.java
@@ -19,7 +19,9 @@ public class DockerVersion implements Comparable<DockerVersion> {
 
     final DockerVersion parsedVersion = new DockerVersion();
     Matcher matcher = versionPattern.matcher(version);
-    matcher.matches();
+    if (!matcher.matches()) {
+      throw new IllegalArgumentException(String.format("Version does not match the expected version pattern: '%s'", version));
+    }
     parsedVersion.setMajor(Integer.parseInt(matcher.group(1)));
     parsedVersion.setMinor(Integer.parseInt(matcher.group(2)));
     final String s = matcher.group(3);

--- a/engine/src/test/groovy/de/gesellix/docker/engine/DockerVersionSpec.groovy
+++ b/engine/src/test/groovy/de/gesellix/docker/engine/DockerVersionSpec.groovy
@@ -7,6 +7,20 @@ import static de.gesellix.docker.engine.DockerVersion.parseDockerVersion
 
 class DockerVersionSpec extends Specification {
 
+  def "fails for invalid version"() {
+    given:
+    // this pattern appears in the wild for packages installed from
+    // https://master.dockerproject.org/
+    String versionString = "master-dockerproject-2022-03-26"
+
+    when:
+    parseDockerVersion(versionString)
+
+    then:
+    def e = thrown(IllegalArgumentException)
+    e.message == "Version does not match the expected version pattern: '$versionString'"
+  }
+
   @Unroll
   def "parse version #versionString"() {
     expect:


### PR DESCRIPTION
Relates to https://github.com/actions/runner-images/pull/6220, which currently uses a nightly built for Windows runners. Also related: https://github.com/microsoft/Windows-Containers/issues/256.
