### PR TITLE
Accept the "application/vnd.docker.multiplexed-stream" response header as of api v1.42

### DIFF
--- a/engine/src/main/java/de/gesellix/docker/engine/OkDockerClient.java
+++ b/engine/src/main/java/de/gesellix/docker/engine/OkDockerClient.java
@@ -347,6 +347,7 @@ public class OkDockerClient implements EngineClient {
       mimeType = "";
     }
     switch (mimeType) {
+      case "application/vnd.docker.multiplexed-stream":
       case "application/vnd.docker.raw-stream":
         InputStream rawStream = new RawInputStream(body.byteStream());
         if (config.getStdout() != null) {

--- a/engine/src/test/groovy/de/gesellix/docker/engine/OkDockerClientSpec.groovy
+++ b/engine/src/test/groovy/de/gesellix/docker/engine/OkDockerClientSpec.groovy
@@ -67,8 +67,7 @@ class OkDockerClientSpec extends Specification {
     cleanup:
     if (oldDockerHost) {
       System.setProperty("docker.host", oldDockerHost)
-    }
-    else {
+    } else {
       System.clearProperty("docker.host")
     }
   }
@@ -108,8 +107,7 @@ class OkDockerClientSpec extends Specification {
     cleanup:
     if (oldDockerCertPath) {
       System.setProperty("docker.cert.path", oldDockerCertPath)
-    }
-    else {
+    } else {
       System.clearProperty("docker.cert.path")
     }
   }
@@ -128,8 +126,7 @@ class OkDockerClientSpec extends Specification {
     cleanup:
     if (oldDockerCertPath) {
       System.setProperty("docker.cert.path", oldDockerCertPath)
-    }
-    else {
+    } else {
       System.clearProperty("docker.cert.path")
     }
   }
@@ -322,8 +319,7 @@ class OkDockerClientSpec extends Specification {
     cleanup:
     if (oldDockerCertPath) {
       System.setProperty("docker.cert.path", oldDockerCertPath)
-    }
-    else {
+    } else {
       System.clearProperty("docker.cert.path")
     }
   }
@@ -479,7 +475,7 @@ class OkDockerClientSpec extends Specification {
 
     when:
     def response = client.request(new EngineRequest(OPTIONS, "/a-resource")
-                                      .tap { apiVersion = "v1.23" })
+        .tap { apiVersion = "v1.23" })
     then:
     response.status.success
     and:
@@ -522,7 +518,7 @@ class OkDockerClientSpec extends Specification {
 
     when:
     def response = client.request(new EngineRequest(OPTIONS, "/a-resource")
-                                      .tap { query = [baz: ["la/la"], answer: ["42"]] })
+        .tap { query = [baz: ["la/la"], answer: ["42"]] })
     then:
     response.status.success
     and:
@@ -536,9 +532,9 @@ class OkDockerClientSpec extends Specification {
     given:
     def mockWebServer = new MockWebServer()
     mockWebServer.enqueue(new MockResponse()
-                              .setResponseCode(101)
-                              .addHeader("Connection", "Upgrade")
-                              .addHeader("Upgrade", "tcp"))
+        .setResponseCode(101)
+        .addHeader("Connection", "Upgrade")
+        .addHeader("Upgrade", "tcp"))
     mockWebServer.start()
 
     def errors = []
@@ -575,14 +571,14 @@ class OkDockerClientSpec extends Specification {
     }
 
     client.request(new EngineRequest(OPTIONS, "/a-resource")
-                       .tap {
-                         attach = new AttachConfig(onResponse: onResponse)
-                         headers = [
-                             "header-a"  : "header-a-value",
-                             "Upgrade"   : "tcp",
-                             "Connection": "Upgrade"
-                         ]
-                       })
+        .tap {
+          attach = new AttachConfig(onResponse: onResponse)
+          headers = [
+              "header-a"  : "header-a-value",
+              "Upgrade"   : "tcp",
+              "Connection": "Upgrade"
+          ]
+        })
     then:
     latch.await(10, TimeUnit.SECONDS)
     and:
@@ -675,8 +671,7 @@ class OkDockerClientSpec extends Specification {
     mockWebServer.shutdown()
     if (oldDockerCertPath) {
       System.setProperty("docker.cert.path", oldDockerCertPath)
-    }
-    else {
+    } else {
       System.clearProperty("docker.cert.path")
     }
   }
@@ -785,7 +780,7 @@ class OkDockerClientSpec extends Specification {
 
     when:
     def response = client.request(new EngineRequest(OPTIONS, "/a-resource")
-                                      .tap { it.stdout = stdout })
+        .tap { it.stdout = stdout })
 
     then:
     stdout.toByteArray() == "holy ship".bytes
@@ -859,7 +854,7 @@ class OkDockerClientSpec extends Specification {
 
     when:
     def response = client.request(new EngineRequest(OPTIONS, "/a-resource")
-                                      .tap { it.stdout = stdout })
+        .tap { it.stdout = stdout })
 
     then:
     stdout.toByteArray() == "holy ship".bytes
@@ -946,7 +941,7 @@ class OkDockerClientSpec extends Specification {
 
     when:
     def response = client.request(new EngineRequest(OPTIONS, "/a-resource")
-                                      .tap { it.stdout = stdout })
+        .tap { it.stdout = stdout })
 
     then:
     stdout.toByteArray() == actualText.bytes
@@ -1045,8 +1040,8 @@ class OkDockerClientSpec extends Specification {
       def hosts = isWindows ? new File("${System.getenv("SystemRoot")}\\System32\\drivers\\etc\\hosts") : new File("/etc/hosts")
       if (hosts.isFile()) {
         whitelist.addAll(hosts.readLines()
-                             .grep({ it.startsWith("127.0.0.1 ") })
-                             .collect({ it.substring("127.0.0.1 ".length()).toLowerCase() }))
+            .grep({ it.startsWith("127.0.0.1 ") })
+            .collect({ it.substring("127.0.0.1 ".length()).toLowerCase() }))
       }
       def isAllowed = host.toLowerCase() in whitelist || host.endsWith(".internal")
       if (!isAllowed) {

--- a/integrationtest/src/test/groovy/de/gesellix/docker/engine/TestConstants.groovy
+++ b/integrationtest/src/test/groovy/de/gesellix/docker/engine/TestConstants.groovy
@@ -12,7 +12,7 @@ class TestConstants {
 
   TestConstants() {
     imageRepo = "gesellix/echo-server"
-    imageTag = "2023-03-12T23-40-00"
+    imageTag = "2023-04-05T20-08-00"
     imageName = "$imageRepo:$imageTag"
 
     if (System.getenv("GITHUB_ACTOR")) {

--- a/integrationtest/src/test/groovy/de/gesellix/docker/engine/TestConstants.groovy
+++ b/integrationtest/src/test/groovy/de/gesellix/docker/engine/TestConstants.groovy
@@ -19,11 +19,11 @@ class TestConstants {
       // TODO consider checking the Docker api version instead of "GITHUB_ACTOR"
       if (LocalDocker.isNativeWindows()) {
         versionDetails = [
-            ApiVersion   : { it == "1.41" },
+            ApiVersion   : { it == "1.42" },
             Arch         : { it in ["amd64", "arm64"] },
-            BuildTime    : { it =~ "2022-\\d{2}-\\d{2}T\\w+" },
+            BuildTime    : { it =~ "2023-\\d{2}-\\d{2}T\\w+" },
             GitCommit    : { it =~ "\\w{6,}" },
-            GoVersion    : { it == "go1.18.7" },
+            GoVersion    : { it == "go1.19.8" },
             KernelVersion: { it =~ "\\d.\\d{1,2}.\\d{1,2}\\w*" },
             MinAPIVersion: { it == "1.24" },
             Os           : { it == "windows" },


### PR DESCRIPTION
See https://docs.docker.com/engine/api/version-history/#v142-api-changes
Relates to https://github.com/docker-client/docker-remote-api-client/pull/294
